### PR TITLE
Resolve https://github.com/Finnhub-Stock-API/finnhub-python/issues/16

### DIFF
--- a/finnhub/client.py
+++ b/finnhub/client.py
@@ -49,6 +49,8 @@ class Client:
                 return response.json()
             if 'text/csv' in content_type:
                 return response.text
+            if 'text/plain' in content_type:
+                return response.text
             raise FinnhubRequestException("Invalid Response: {}".format(response.text))
         except ValueError:
             raise FinnhubRequestException("Invalid Response: {}".format(response.text))


### PR DESCRIPTION
The API returns a content-type of 'text/plain' instead of either 'application/json' or 'text/csv'. This is either an oversight in the API code and this pull request should be denied, or this was not considered after changes to the API were made and this pull request needs to be merged to master.