### PR TITLE
Fix earnings_calendar with correct parameter mappings

### DIFF
--- a/finnhub/client.py
+++ b/finnhub/client.py
@@ -332,8 +332,13 @@ class Client:
     def calendar_economic(self):
         return self._get("/calendar/economic")
 
-    def earnings_calendar(self, **params):
-        return self._get("/calendar/earnings", params=params)
+    def earnings_calendar(self, _from, to, symbol, international=False):
+        return self._get("/calendar/earnings", params={
+            "from": _from,
+            "to": to,
+            "symbol": symbol,
+            "international": international
+        })
 
     def ipo_calendar(self, _from, to):
         return self._get("/calendar/ipo", params={


### PR DESCRIPTION
Without `_from -> from` mapping, `earnings_calendar` endpoint will not work.